### PR TITLE
Resolve contextual binding in CallProxy

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,9 +2,8 @@ name: phpstan
 
 on:
   push:
-    paths:
-      - '**.php'
-      - 'phpstan.neon'
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/src/Core/CallProxy.php
+++ b/src/Core/CallProxy.php
@@ -29,14 +29,17 @@ class CallProxy implements Call
      *
      * @param object|class-string $class
      * @param array               $dependencies
+     * @param string|null         $contextual
      */
     public function __construct(
         private object | string $class,
-        private array $dependencies = []
+        private array $dependencies = [],
+        private ?string $contextual = null
     ) {
         $this->instance = $this->resolvePassedClass(
             $this->class,
-            $this->dependencies
+            $this->dependencies,
+            $this->contextual
         );
 
         $this->forwardsTo = (new MethodForwarder(

--- a/src/Core/CallProxy.php
+++ b/src/Core/CallProxy.php
@@ -68,6 +68,18 @@ class CallProxy implements Call
     }
 
     /**
+     * Gets the internal property by name.
+     *
+     * @param string $property
+     *
+     * @return mixed
+     */
+    public function getInternal(string $property): mixed
+    {
+        return $this->{$property};
+    }
+
+    /**
      * Pass the call through container.
      *
      * @param string $method

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -9,12 +9,13 @@ if (! function_exists('call')) {
     /**
      * @param string|object $class
      * @param array         $parameters
+     * @param string|null   $contextual
      *
      * @return mixed
      */
-    function call(string|object $class, array $parameters = []): mixed
+    function call(string|object $class, array $parameters = [], ?string $contextual = null): mixed
     {
-        return app(Call::class, [$class, $parameters]);
+        return app(Call::class, [$class, $parameters, $contextual]);
     }
 }
 

--- a/src/LecServiceProvider.php
+++ b/src/LecServiceProvider.php
@@ -35,6 +35,7 @@ class LecServiceProvider extends PackageServiceProvider
         $this->app->bind(Call::class, function (Application $app, array $params) {
             return new CallProxy(
                 current($params),
+                next($params),
                 end($params)
             );
         });

--- a/src/Traits/HelpsProxies.php
+++ b/src/Traits/HelpsProxies.php
@@ -12,13 +12,18 @@ trait HelpsProxies
     /**
      * @param object|class-string $class
      * @param array               $dependencies
+     * @param string|null         $contextual
      *
      * @return object
      */
-    public function resolvePassedClass(object|string $class, array $dependencies = []): object
+    public function resolvePassedClass(object|string $class, array $dependencies = [], ?string $contextual = null): object
     {
         if (is_object($class)) {
             return $class;
+        }
+
+        if (! is_null($contextual) && isset(app()->contextual[$contextual])) {
+            $class = app()->contextual[$contextual][$class];
         }
 
         try {

--- a/tests/Boilerplate/BoilerplateServiceResolvesContextualInMethod.php
+++ b/tests/Boilerplate/BoilerplateServiceResolvesContextualInMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MichaelRubel\EnhancedContainer\Tests\Boilerplate;
+
+use MichaelRubel\EnhancedContainer\Core\CallProxy;
+
+class BoilerplateServiceResolvesContextualInMethod implements BoilerplateInterface
+{
+    /**
+     * @return CallProxy
+     */
+    public function hasContextual(): CallProxy
+    {
+        return call(BoilerplateInterface::class);
+    }
+}

--- a/tests/Boilerplate/BoilerplateServiceResolvesContextualInMethod.php
+++ b/tests/Boilerplate/BoilerplateServiceResolvesContextualInMethod.php
@@ -38,4 +38,12 @@ class BoilerplateServiceResolvesContextualInMethod implements BoilerplateInterfa
     {
         return call(BoilerplateInterface::class, [], static::class);
     }
+
+    /**
+     * @return CallProxy
+     */
+    public function methodHasGlobal(): CallProxy
+    {
+        return call(BoilerplateInterface::class);
+    }
 }

--- a/tests/Boilerplate/BoilerplateServiceResolvesContextualInMethod.php
+++ b/tests/Boilerplate/BoilerplateServiceResolvesContextualInMethod.php
@@ -9,11 +9,26 @@ use MichaelRubel\EnhancedContainer\Core\CallProxy;
 class BoilerplateServiceResolvesContextualInMethod implements BoilerplateInterface
 {
     /**
+     * @param BoilerplateInterface $boilerplate
+     */
+    public function __construct(protected BoilerplateInterface $boilerplate)
+    {
+    }
+
+    /**
+     * @return object
+     */
+    public function constructorHasContextual(): object
+    {
+        return $this->boilerplate;
+    }
+
+    /**
      * @return CallProxy
      */
     public function methodHasContextual(): CallProxy
     {
-        return call(BoilerplateInterface::class);
+        return call(BoilerplateInterface::class, [], static::class);
     }
 
     /**
@@ -21,6 +36,6 @@ class BoilerplateServiceResolvesContextualInMethod implements BoilerplateInterfa
      */
     public function methodHasContextual2(): CallProxy
     {
-        return call(BoilerplateInterface::class);
+        return call(BoilerplateInterface::class, [], static::class);
     }
 }

--- a/tests/Boilerplate/BoilerplateServiceResolvesContextualInMethod.php
+++ b/tests/Boilerplate/BoilerplateServiceResolvesContextualInMethod.php
@@ -11,7 +11,15 @@ class BoilerplateServiceResolvesContextualInMethod implements BoilerplateInterfa
     /**
      * @return CallProxy
      */
-    public function hasContextual(): CallProxy
+    public function methodHasContextual(): CallProxy
+    {
+        return call(BoilerplateInterface::class);
+    }
+
+    /**
+     * @return CallProxy
+     */
+    public function methodHasContextual2(): CallProxy
     {
         return call(BoilerplateInterface::class);
     }

--- a/tests/Boilerplate/BoilerplateServiceResolvesGlobalInMethod.php
+++ b/tests/Boilerplate/BoilerplateServiceResolvesGlobalInMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MichaelRubel\EnhancedContainer\Tests\Boilerplate;
+
+use MichaelRubel\EnhancedContainer\Core\CallProxy;
+
+class BoilerplateServiceResolvesGlobalInMethod implements BoilerplateInterface
+{
+    /**
+     * @return CallProxy
+     */
+    public function getsGlobalBinding(): CallProxy
+    {
+        return call(BoilerplateInterface::class);
+    }
+}

--- a/tests/Boilerplate/BoilerplateServiceResolvesGlobalInMethod.php
+++ b/tests/Boilerplate/BoilerplateServiceResolvesGlobalInMethod.php
@@ -13,6 +13,6 @@ class BoilerplateServiceResolvesGlobalInMethod implements BoilerplateInterface
      */
     public function getsGlobalBinding(): CallProxy
     {
-        return call(BoilerplateInterface::class);
+        return call(BoilerplateInterface::class, [], static::class);
     }
 }

--- a/tests/Boilerplate/Services/TestService.php
+++ b/tests/Boilerplate/Services/TestService.php
@@ -2,9 +2,10 @@
 
 namespace MichaelRubel\EnhancedContainer\Tests\Boilerplate\Services;
 
+use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateInterface;
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\Repositories\TestRepository;
 
-class TestService
+class TestService implements BoilerplateInterface
 {
     /**
      * @param TestRepository $testRepository

--- a/tests/ContextualBindingTest.php
+++ b/tests/ContextualBindingTest.php
@@ -138,10 +138,7 @@ class ContextualBindingTest extends TestCase
 
         $call = call(BoilerplateInterface::class);
 
-        $this->assertInstanceOf(
-            BoilerplateService::class,
-            $call->getInternal('instance')
-        );
+        $this->assertInstanceOf(BoilerplateService::class, $call->getInternal('instance'));
 
         // set contextual
         bind(BoilerplateInterface::class)
@@ -150,32 +147,13 @@ class ContextualBindingTest extends TestCase
 
         $service = call(BoilerplateServiceResolvesContextualInMethod::class);
 
-        $this->assertInstanceOf(
-            TestService::class,
-            $service->constructorHasContextual()
-        );
-
-        $this->assertInstanceOf(
-            TestService::class,
-            $service->methodHasContextual()->getInternal('instance')
-        );
-
-        $this->assertInstanceOf(
-            TestService::class,
-            $service->methodHasContextual2()->getInternal('instance')
-        );
-
-        $this->assertInstanceOf(
-            BoilerplateService::class,
-            $service->methodHasGlobal()->getInternal('instance')
-        );
+        $this->assertInstanceOf(TestService::class, $service->constructorHasContextual());
+        $this->assertInstanceOf(TestService::class, $service->methodHasContextual()->getInternal('instance'));
+        $this->assertInstanceOf(TestService::class, $service->methodHasContextual2()->getInternal('instance'));
+        $this->assertInstanceOf(BoilerplateService::class, $service->methodHasGlobal()->getInternal('instance'));
 
         // ensure global still available for other classes
         $service = call(BoilerplateServiceResolvesGlobalInMethod::class);
-
-        $this->assertInstanceOf(
-            BoilerplateService::class,
-            $service->getsGlobalBinding()->getInternal('instance')
-        );
+        $this->assertInstanceOf(BoilerplateService::class, $service->getsGlobalBinding()->getInternal('instance'));
     }
 }

--- a/tests/ContextualBindingTest.php
+++ b/tests/ContextualBindingTest.php
@@ -4,11 +4,14 @@ namespace MichaelRubel\EnhancedContainer\Tests;
 
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateInterface;
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateService;
+use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateServiceResolvesContextualInMethod;
+use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateServiceResolvesGlobalInMethod;
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateServiceWithConstructor;
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateServiceWithConstructorClass;
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateServiceWithConstructorPrimitive;
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateServiceWithVariadicConstructor;
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateServiceWithWrongContext;
+use MichaelRubel\EnhancedContainer\Tests\Boilerplate\Services\TestService;
 
 class ContextualBindingTest extends TestCase
 {
@@ -124,5 +127,40 @@ class ContextualBindingTest extends TestCase
         )->getParam();
 
         $this->assertTrue($test);
+    }
+
+    /** @test */
+    public function testCallProxyResolvesContextualBinding()
+    {
+        // bind global service
+        bind(BoilerplateInterface::class)
+            ->singleton(BoilerplateService::class);
+
+        $call = call(BoilerplateInterface::class);
+
+        $this->assertInstanceOf(
+            BoilerplateService::class,
+            $call->getInternal('instance')
+        );
+
+        // set contextual
+        bind(BoilerplateInterface::class)
+            ->contextual(TestService::class)
+            ->for(BoilerplateServiceResolvesContextualInMethod::class);
+
+        $service = call(BoilerplateServiceResolvesContextualInMethod::class);
+
+        $this->assertInstanceOf(
+            TestService::class,
+            $service->hasContextual()->getInternal('instance')
+        );
+
+        // ensure global still available for other classes
+        $service = call(BoilerplateServiceResolvesGlobalInMethod::class);
+
+        $this->assertInstanceOf(
+            BoilerplateService::class,
+            $service->getsGlobalBinding()->getInternal('instance')
+        );
     }
 }

--- a/tests/ContextualBindingTest.php
+++ b/tests/ContextualBindingTest.php
@@ -129,43 +129,48 @@ class ContextualBindingTest extends TestCase
         $this->assertTrue($test);
     }
 
-//    /** @test */
-//    public function testCallProxyResolvesContextualBinding()
-//    {
-//        // bind global service
-//        bind(BoilerplateInterface::class)
-//            ->singleton(BoilerplateService::class);
-//
-//        $call = call(BoilerplateInterface::class);
-//
-//        $this->assertInstanceOf(
-//            BoilerplateService::class,
-//            $call->getInternal('instance')
-//        );
-//
-//        // set contextual
-//        bind(BoilerplateInterface::class)
-//            ->contextual(TestService::class)
-//            ->for(BoilerplateServiceResolvesContextualInMethod::class);
-//
-//        $service = call(BoilerplateServiceResolvesContextualInMethod::class);
-//
-//        $this->assertInstanceOf(
-//            TestService::class,
-//            $service->methodHasContextual()->getInternal('instance')
-//        );
-//
-//        $this->assertInstanceOf(
-//            TestService::class,
-//            $service->methodHasContextual2()->getInternal('instance')
-//        );
-//
-//        // ensure global still available for other classes
-//        $service = call(BoilerplateServiceResolvesGlobalInMethod::class);
-//
-//        $this->assertInstanceOf(
-//            BoilerplateService::class,
-//            $service->getsGlobalBinding()->getInternal('instance')
-//        );
-//    }
+    /** @test */
+    public function testCallProxyResolvesContextualBinding()
+    {
+        // bind the service globally
+        bind(BoilerplateInterface::class)
+            ->singleton(BoilerplateService::class);
+
+        $call = call(BoilerplateInterface::class);
+
+        $this->assertInstanceOf(
+            BoilerplateService::class,
+            $call->getInternal('instance')
+        );
+
+        // set contextual
+        bind(BoilerplateInterface::class)
+            ->contextual(TestService::class)
+            ->for(BoilerplateServiceResolvesContextualInMethod::class);
+
+        $service = call(BoilerplateServiceResolvesContextualInMethod::class);
+
+        $this->assertInstanceOf(
+            TestService::class,
+            $service->constructorHasContextual()
+        );
+
+        $this->assertInstanceOf(
+            TestService::class,
+            $service->methodHasContextual()->getInternal('instance')
+        );
+
+        $this->assertInstanceOf(
+            TestService::class,
+            $service->methodHasContextual2()->getInternal('instance')
+        );
+
+        // ensure global still available for other classes
+        $service = call(BoilerplateServiceResolvesGlobalInMethod::class);
+
+        $this->assertInstanceOf(
+            BoilerplateService::class,
+            $service->getsGlobalBinding()->getInternal('instance')
+        );
+    }
 }

--- a/tests/ContextualBindingTest.php
+++ b/tests/ContextualBindingTest.php
@@ -129,38 +129,43 @@ class ContextualBindingTest extends TestCase
         $this->assertTrue($test);
     }
 
-    /** @test */
-    public function testCallProxyResolvesContextualBinding()
-    {
-        // bind global service
-        bind(BoilerplateInterface::class)
-            ->singleton(BoilerplateService::class);
-
-        $call = call(BoilerplateInterface::class);
-
-        $this->assertInstanceOf(
-            BoilerplateService::class,
-            $call->getInternal('instance')
-        );
-
-        // set contextual
-        bind(BoilerplateInterface::class)
-            ->contextual(TestService::class)
-            ->for(BoilerplateServiceResolvesContextualInMethod::class);
-
-        $service = call(BoilerplateServiceResolvesContextualInMethod::class);
-
-        $this->assertInstanceOf(
-            TestService::class,
-            $service->hasContextual()->getInternal('instance')
-        );
-
-        // ensure global still available for other classes
-        $service = call(BoilerplateServiceResolvesGlobalInMethod::class);
-
-        $this->assertInstanceOf(
-            BoilerplateService::class,
-            $service->getsGlobalBinding()->getInternal('instance')
-        );
-    }
+//    /** @test */
+//    public function testCallProxyResolvesContextualBinding()
+//    {
+//        // bind global service
+//        bind(BoilerplateInterface::class)
+//            ->singleton(BoilerplateService::class);
+//
+//        $call = call(BoilerplateInterface::class);
+//
+//        $this->assertInstanceOf(
+//            BoilerplateService::class,
+//            $call->getInternal('instance')
+//        );
+//
+//        // set contextual
+//        bind(BoilerplateInterface::class)
+//            ->contextual(TestService::class)
+//            ->for(BoilerplateServiceResolvesContextualInMethod::class);
+//
+//        $service = call(BoilerplateServiceResolvesContextualInMethod::class);
+//
+//        $this->assertInstanceOf(
+//            TestService::class,
+//            $service->methodHasContextual()->getInternal('instance')
+//        );
+//
+//        $this->assertInstanceOf(
+//            TestService::class,
+//            $service->methodHasContextual2()->getInternal('instance')
+//        );
+//
+//        // ensure global still available for other classes
+//        $service = call(BoilerplateServiceResolvesGlobalInMethod::class);
+//
+//        $this->assertInstanceOf(
+//            BoilerplateService::class,
+//            $service->getsGlobalBinding()->getInternal('instance')
+//        );
+//    }
 }

--- a/tests/ContextualBindingTest.php
+++ b/tests/ContextualBindingTest.php
@@ -165,6 +165,11 @@ class ContextualBindingTest extends TestCase
             $service->methodHasContextual2()->getInternal('instance')
         );
 
+        $this->assertInstanceOf(
+            BoilerplateService::class,
+            $service->methodHasGlobal()->getInternal('instance')
+        );
+
         // ensure global still available for other classes
         $service = call(BoilerplateServiceResolvesGlobalInMethod::class);
 


### PR DESCRIPTION
### Topic
This PR adds the ability to resolve contextual bindings in any available class method based on the third parameter passed to the proxy.

```php
singleton(BoilerplateInterface::class, BoilerplateService::class);

// defines the implementation globally
```

```php
bind(BoilerplateInterface::class)
    ->contextual(TestService::class)
    ->for(BoilerplateServiceResolvesContextualInMethod::class);

// defines contextual implementation
```

In `BoilerplateServiceResolvesContextualInMethod` class:
```php
call(BoilerplateInterface::class, [], static::class);

// static class identifies the context
// returns contextual implementation (TestService::class)
```

```php
call(BoilerplateInterface::class);

// in the same class
// returns global implementation (BoilerplateService::class)
```

### Additional:
- new` getInternal` method to get proxy's internal properties.

```php
call(BoilerplateInterface::class)->getInternal('instance');
```

### B/C
- `getInternal` method is considered as breaking if someone used the same method before this addition.

