### PR TITLE
Fix for non-associative arrays

### DIFF
--- a/src/Traits/InteractsWithContainer.php
+++ b/src/Traits/InteractsWithContainer.php
@@ -83,7 +83,7 @@ trait InteractsWithContainer
      */
     protected function getDependencies(string $class, array $dependencies = []): array
     {
-        if (! empty($dependencies)) {
+        if (! Arr::isAssoc($dependencies)) {
             if (! class_exists($class)) {
                 $class = $this->getBindingConcrete($class);
             }

--- a/tests/ContainerCallTest.php
+++ b/tests/ContainerCallTest.php
@@ -12,6 +12,7 @@ use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateService;
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateServiceWithConstructor;
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\BoilerplateServiceWithConstructorPrimitive;
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\ParameterOrderBoilerplate;
+use MichaelRubel\EnhancedContainer\Tests\Boilerplate\Repositories\TestRepository;
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\Repositories\Users\UserRepository;
 use MichaelRubel\EnhancedContainer\Tests\Boilerplate\Services\Users\UserService;
 
@@ -247,6 +248,15 @@ class ContainerCallTest extends TestCase
         $call = new TestCallProxy(UserService::class);
         $this->assertTrue($call->existingMethod());
         $call->nonExistingMethod();
+    }
+
+    /** @test */
+    public function testParsesNonAssociativeArraysWhenResolvingDependencies()
+    {
+        $repo = app(TestRepository::class);
+        $call = call(UserService::class, [0 => app(TestRepository::class), 1 => true]);
+        $this->assertEquals($call->testRepository, $repo);
+        $this->assertTrue($call->existingProperty);
     }
 }
 


### PR DESCRIPTION
## About

This PR fixes passing non-associative arrays to `call` parameters.

---