### PR TITLE
Add `remember` method

### DIFF
--- a/src/Overrides/Container.php
+++ b/src/Overrides/Container.php
@@ -722,11 +722,10 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Bind the given type to the container with the results of the callback.
      *
-     * @param $abstract
-     * @param  Closure|null  $callback
+     * @param  string  $abstract
+     * @param  \Closure|null  $callback
      * @param  string  $type
-     *
-     * @return void
+     * @return mixed
      */
     public function remember($abstract, Closure $callback = null, $type = 'scoped')
     {

--- a/src/Overrides/Container.php
+++ b/src/Overrides/Container.php
@@ -720,6 +720,26 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Bind the given type to the container with the results of the callback.
+     *
+     * @param $abstract
+     * @param  Closure|null  $callback
+     * @param  string  $type
+     *
+     * @return void
+     */
+    public function remember($abstract, Closure $callback = null, $type = 'scoped')
+    {
+        return $this->makeOr($abstract, function () use ($abstract, $callback, $type) {
+            $result = $callback($this);
+
+            $this->{$type}($abstract, fn () => $result);
+
+            return $result;
+        });
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return mixed

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -726,6 +726,24 @@ class ContainerTest extends TestCase
         $container = new Container;
         $container->makeOr(ContainerInjectVariableStub::class);
     }
+
+    public function testRemember()
+    {
+        $container = new Container;
+        $callback  = function ($app) {
+            $app->bind('executed', fn () => 'once');
+
+            return true;
+        };
+
+        $var1 = $container->remember('test', $callback);
+        $this->assertTrue($var1);
+
+        $var2 = $container->remember('test', $callback);
+        $this->assertTrue($var2);
+
+        $this->assertSame('once', $container->make('executed'));
+    }
 }
 
 class CircularAStub


### PR DESCRIPTION
## About

Adds `remember` method allowing to resolve or execute the callback & bind results to the service container.

```php
app()->remember('key', fn () => 'result');
```

---