### PR TITLE
Patch container

### DIFF
--- a/src/Overrides/Container.php
+++ b/src/Overrides/Container.php
@@ -678,20 +678,12 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getClassForCallable($callback)
     {
-        if (PHP_VERSION_ID >= 80200) {
-            if (is_callable($callback) &&
-                ! ($reflector = new ReflectionFunction($callback(...)))->isAnonymous()) {
-                return $reflector->getClosureScopeClass()->name ?? false;
-            }
-
-            return false;
+        if (is_callable($callback) &&
+            ! ($reflector = new ReflectionFunction($callback(...)))->isAnonymous()) {
+            return $reflector->getClosureScopeClass()->name ?? false;
         }
 
-        if (! is_array($callback)) {
-            return false;
-        }
-
-        return is_string($callback[0]) ? $callback[0] : get_class($callback[0]);
+        return false;
     }
 
     /**


### PR DESCRIPTION
# About

Removes PHP 8.2 checks (ref: https://github.com/laravel/framework/commit/25aeb5f76571cf19a07b392897d44cf72bdbdb9c)